### PR TITLE
게시판 대대적 수정

### DIFF
--- a/src/main/java/org/kosta/starducks/forum/dto/ForumPostUpdateDTO.java
+++ b/src/main/java/org/kosta/starducks/forum/dto/ForumPostUpdateDTO.java
@@ -1,0 +1,37 @@
+package org.kosta.starducks.forum.dto;
+
+/**
+ * 게시글 수정할 때 필요한 부분만 수정하도록 DTO 사용
+ */
+public class ForumPostUpdateDTO {
+  private String postTitle; // 게시글 제목
+  private String postContent; // 게시글 내용
+  private boolean postNotice; // 공지사항 여부
+
+  public String getPostTitle() {
+    return postTitle;
+  }
+
+  public void setPostTitle(String postTitle) {
+    this.postTitle = postTitle;
+  }
+
+  public String getPostContent() {
+    return postContent;
+  }
+
+  public void setPostContent(String postContent) {
+    this.postContent = postContent;
+  }
+
+  public boolean isPostNotice() {
+    return postNotice;
+  }
+
+  public void setPostNotice(boolean postNotice) {
+    this.postNotice = postNotice;
+  }
+
+
+
+}

--- a/src/main/java/org/kosta/starducks/forum/entity/ForumPost.java
+++ b/src/main/java/org/kosta/starducks/forum/entity/ForumPost.java
@@ -30,7 +30,7 @@ public class ForumPost {
   @UpdateTimestamp
   private LocalDateTime updateDate; //게시글 수정 시간
 
-  private int postView; //조회수. 로직 추가해서 동일한 사용자면 조회수 카운트 방지 가능
+  private int postView; //조회수
 
   private boolean postDelete; //삭제 여부. 기본적으로 삭제 아님(false)
 

--- a/src/main/java/org/kosta/starducks/forum/repository/ForumPostRepository.java
+++ b/src/main/java/org/kosta/starducks/forum/repository/ForumPostRepository.java
@@ -10,5 +10,5 @@ public interface ForumPostRepository extends JpaRepository<ForumPost, Long> {
     List<ForumPost> findByPostTitleContainingOrPostContentContaining(String title, String content);
     //제목과 내용으로 검색하는 기능
 
-    List<ForumPost> findAllByOrderByPostDateDesc(); // 최신순 게시글 정렬
+
 }

--- a/src/main/java/org/kosta/starducks/forum/service/ForumPostService.java
+++ b/src/main/java/org/kosta/starducks/forum/service/ForumPostService.java
@@ -1,6 +1,8 @@
 package org.kosta.starducks.forum.service;
 
 import org.kosta.starducks.forum.entity.ForumPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,9 +17,7 @@ public interface ForumPostService {
 
   Optional<ForumPost> getPostById(Long id); // 게시글 상세 정보로 가기 위한 식별 수단
 
-  List<ForumPost> getAllForumPosts(); // 게시글 목록 생성을 위해 모두 가져오기 **최신순 정렬만 필요하면 나중에 없애기**
-
-  List<ForumPost> getAllForumPostsSorted(); //게시글 정렬해서 가져오기
+  Page<ForumPost> postList(Pageable pageable); //게시글 리스트 처리
 
   List<ForumPost> searchPosts(String keyword); //제목과 내용 검색 기능
 

--- a/src/main/java/org/kosta/starducks/forum/service/ForumPostServiceImpl.java
+++ b/src/main/java/org/kosta/starducks/forum/service/ForumPostServiceImpl.java
@@ -3,6 +3,8 @@ package org.kosta.starducks.forum.service;
 import org.kosta.starducks.forum.entity.ForumPost;
 import org.kosta.starducks.forum.repository.ForumPostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -39,15 +41,13 @@ public class ForumPostServiceImpl implements ForumPostService {
     return forumPostRepository.findById(id); // 게시글 ID로 게시글 조회
   }
 
+
+  //페이지 기능 구현
   @Override
-  public List<ForumPost> getAllForumPosts() {
-    return forumPostRepository.findAll(); // 모든 게시글 조회
+  public Page<ForumPost> postList(Pageable pageable) {
+    return forumPostRepository.findAll(pageable);
   }
 
-  @Override
-  public List<ForumPost> getAllForumPostsSorted() {
-    return forumPostRepository.findAllByOrderByPostDateDesc();
-  }
 
   @Override //게시글 제목, 내용 검색 기능
   public List<ForumPost> searchPosts(String keyword) {

--- a/src/main/resources/static/css/commons/style.css
+++ b/src/main/resources/static/css/commons/style.css
@@ -137,6 +137,8 @@ header a {
 a p.commonBtn {
     line-height: 50px;
     display: inline-block;
+    text-align: center;
+    /* 글자 가운데 정렬 추가 */
 }
 
 /* 등록 */

--- a/src/main/resources/static/css/forum/style.css
+++ b/src/main/resources/static/css/forum/style.css
@@ -106,7 +106,17 @@
     background-color: #f5f5f5;
 }
 
+/*게시글 작성 페이지~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+.checkbox-container {
+    display: flex; /* Flexbox 레이아웃 사용 */
+    align-items: center; /* 세로축(center)으로 정렬 */
+    gap: 10px; /* 체크박스와 라벨 사이의 간격 */
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
 
+
+/*게시글 작성 페이지~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 /*게시글 상세 페이지~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 .detail-page-container {
     align-items: center;
@@ -194,4 +204,70 @@
     margin-right: 5px;
 }
 
+/*수정, 삭제, 목록 버튼이 좌우로 보이도록 묶음 */
+.button-group {
+    display: flex;
+    justify-content: space-between; /* 버튼들 사이에 균일한 간격을 두기 위함 */
+    margin-top: 20px; /* 추가적인 상단 여백을 위함 */
+}
+
+.button-group a {
+    margin-right: 10px; /* 각 링크(버튼) 사이의 간격 */
+}
+
 /*게시물 상세 페이지 끝~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+
+/*페이지네이션 스타일 ~~~~~~~~~~~~~~~~~~*/
+.pagination {
+    display: flex;
+    justify-content: center;
+    list-style: none;
+}
+
+.pagination a,
+.pagination strong {
+    padding: 5px 10px;
+    margin: 0 2px;
+    border: 1px solid #ddd;
+    color: #333;
+    text-decoration: none;
+}
+
+.pagination a:hover {
+    background-color: #f4f4f4;
+}
+
+.pagination .current-page,
+.pagination a:hover {
+    background-color: #f0f0f0;
+    border-color: #666;
+}
+
+/* Style for current page */
+.pagination .current-page {
+    background-color: #fff;
+    border-color: #666;
+    color: red;
+    font-weight: bold;
+}
+
+/* Custom styles for first and last page links */
+.pagination a:first-child,
+.pagination a:last-child {
+    background-color: #ddd;
+}
+
+/* Styles for disabled previous and next links */
+.pagination a[disabled] {
+    color: grey;
+    pointer-events: none;
+}
+
+.disabled {
+    color: grey;
+    pointer-events: none;
+    cursor: default;
+}
+
+/*페이지네이션 스타일 끝~~~~~~~~~~~~*/

--- a/src/main/resources/static/js/forum/script.js
+++ b/src/main/resources/static/js/forum/script.js
@@ -1,4 +1,4 @@
-function quilljsediterInit() {
+function quilljsediterInit(postContent) {
     var options = {
         modules: {
             toolbar: [
@@ -13,6 +13,12 @@ function quilljsediterInit() {
     };
 
     var quill = new Quill('#editor', options);
+
+    // 수정 페이지에서 게시글 내용을 보이도록 에디터에 설정
+    if (postContent) {
+        quill.clipboard.dangerouslyPasteHTML(postContent);
+    }
+
 
     // 에디터 내용이 변경될 때마다 숨겨진 입력 필드에 값을 업데이트
     quill.on('text-change', function() {
@@ -61,11 +67,12 @@ function quilljsediterInit() {
 
 // 페이지 로드 완료 시 에디터 초기화
 window.onload = function() {
-    quilljsediterInit();
+    var postContent = document.getElementById('quill_html').value; // 숨겨진 필드에서 내용을 가져옴
+    quilljsediterInit(postContent); // 에디터 초기화 함수에 내용 전달
 };
 
 
-/**
+/** 콘텐츠 내용에서 <p>태그가 자꾸 보여서 없애려는 수단 나중에 시도해보기
 $(document).ready(function() {
     var content = $("#content").html(); // 여기서 'content'는 실제 요소의 ID에 맞게 변경해야 합니다.
 

--- a/src/main/resources/templates/forum/forum.html
+++ b/src/main/resources/templates/forum/forum.html
@@ -55,8 +55,29 @@
     </table>
 
     <div class="add-post">
-        <a href="/forum/add" class="register-button">+글쓰기</a>
+        <a href="/forum/add" class="commonBtn register-button">+글쓰기</a>
     </div>
+    <div class="pagination">
+        <!-- Link to the first page -->
+        <a th:href="@{/forum(page=0)}"> << </a>
+
+        <!-- Link to the previous page -->
+        <a th:href="@{/forum(page=${nowPage - 2})}"
+           th:classappend="${nowPage == 1} ? 'disabled' : ''"> < </a>
+
+        <th:block th:each="page : ${#numbers.sequence(startPage, endPage)}">
+            <a th:if="${page != nowPage}" th:href="@{/forum(page=${page - 1})}" th:text="${page}"></a>
+            <strong th:if="${page == nowPage}" th:text="${page}" class="current-page"></strong>
+        </th:block>
+
+        <!-- Link to the next page -->
+        <a th:href="@{/forum(page=${nowPage})}"
+           th:classappend="${nowPage == totalPages} ? 'disabled' : ''"> > </a>
+
+        <!-- Link to the last page -->
+        <a th:href="@{/forum(page=${totalPages - 1})}"> >> </a>
+    </div>
+
 </main>
 </html>
 

--- a/src/main/resources/templates/forum/forumAddPost.html
+++ b/src/main/resources/templates/forum/forumAddPost.html
@@ -21,6 +21,12 @@
         <!-- 제목 입력란 -->
         <input type="text" th:field="*{post.postTitle}" placeholder="제목">
 
+        <!-- 공지사항 체크박스 -->
+        <div class="checkbox-container">
+            <input type="checkbox" id="postNotice" name="postNotice" th:checked="${post.postNotice}">
+            <label for="postNotice">공지로 등록</label>
+        </div>
+
         <!-- Quill 에디터의 메인 컨테이너 -->
         <div id="editor"></div>
 
@@ -28,8 +34,10 @@
         <input type="hidden" id="quill_html" th:field="*{post.postContent}">
 
         <!-- 제출 버튼 -->
-        <button type="submit">작성</button>
-        <a href="/forum">취소</a>
+        <button type="submit" class="commonBtn register-button">작성</button>
+        <a href="/forum">
+            <p class="commonBtn cancel-button">취소</p>
+        </a>
     </form>
 </main>
 </html>

--- a/src/main/resources/templates/forum/forumEditPost.html
+++ b/src/main/resources/templates/forum/forumEditPost.html
@@ -18,10 +18,26 @@
 <main layout:fragment="content">
   <h1>게시글 수정</h1>
   <form th:action="@{/forum/edit/{id}(id=${post.postId})}" th:object="${post}" method="post">
+    <!-- 제목 입력란 -->
     <input type="text" th:field="*{postTitle}" placeholder="제목">
-    <textarea th:field="*{postContent}" placeholder="내용"></textarea>
-    <a href="/forum"><button type="submit">수정 완료</button></a>
-    <a href="/forum">취소</a>
+
+    <!-- 공지사항 체크박스 -->
+    <div class="checkbox-container">
+      <input type="checkbox" id="postNotice" name="postNotice" th:checked="${post.postNotice}">
+      <label for="postNotice">공지로 등록</label>
+    </div>
+
+    <!-- Quill 에디터의 메인 컨테이너 -->
+    <div id="editor"></div>
+
+    <!-- Quill 에디터의 내용을 저장할 숨겨진 input 필드 -->
+    <input type="hidden" id="quill_html" th:field="*{postContent}">
+
+    <!-- 수정, 취소 버튼 -->
+    <button type="submit" class="commonBtn register-button">수정 완료</button>
+    <a th:href="@{/forum/post/{id}(id=${post.postId})}">
+      <p class="commonBtn cancel-button">취소</p>
+    </a>
   </form>
 </main>
 </html>

--- a/src/main/resources/templates/forum/forumPostDetail.html
+++ b/src/main/resources/templates/forum/forumPostDetail.html
@@ -48,10 +48,11 @@
             </div>
         </div>
 
-        <!-- 게시글 수정 및 삭제 링크 -->
-        <a th:href="@{/forum/edit/{id}(id=${post.postId})}"><button class="commonBtn edit-button">수정</button></a>
-        <a th:href="@{/forum/delete/{id}(id=${post.postId})}" th:onclick="'return confirm(\'정말 삭제하시겠습니까?\');'"><button class="commonBtn delete-button">삭제</button></a>
-        <a href="/forum"><button class="commonBtn cancel-button">목록</button></a>
+        <div class="button-group">
+            <a th:href="@{/forum/edit/{id}(id=${post.postId})}"><button class="commonBtn edit-button">수정</button></a>
+            <a th:href="@{/forum/delete/{id}(id=${post.postId})}" th:onclick="'return confirm(\'정말 삭제하시겠습니까?\');'"><button class="commonBtn delete-button">삭제</button></a>
+            <a href="/forum"><button class="commonBtn cancel-button">목록</button></a>
+        </div>
     </div>
 </main>
 </html>


### PR DESCRIPTION
글 수정 페이지도 글 작성 페이지와 구성이 같게 변경.
게시판 글 정렬 순서 기준을 포스트 아이디로 변경, 
페이지네이션 구현, 디자인도 간단하게 구성(forum.css)에 했음. 
DTO 생성해서 글 수정할 때 필요한 것만 바뀌도록. 
버튼들 공통 속성 받아오도록 했음. 
글 상세 페이지에서 수정 눌렀을 때 글 내용이 그대로 옮겨오도록 수정
수정 페이지에서 취소를 누르면 상세 페이지로 복귀하도록 수정